### PR TITLE
Fix dying with "Cannot read : No such file or directory" error

### DIFF
--- a/lib/DateTime/TimeZone/Local/Unix.pm
+++ b/lib/DateTime/TimeZone/Local/Unix.pm
@@ -180,7 +180,7 @@ sub FromEtcSysconfigClock {
     my $clock_file = $class->_EtcFile('sysconfig/clock');
     return unless -r $clock_file && -f _;
 
-    my $name = $class->_ReadEtcSysconfigClock();
+    my $name = $class->_ReadEtcSysconfigClock($clock_file);
 
     return unless $class->_IsValidName($name);
 


### PR DESCRIPTION
The error comes from the _ReadEtcSysconfigClock() function and happens
in case if it was called without passing a mandatory parameter to it.

Unfortunately, FromEtcSysconfigClock() calls _ReadEtcSysconfigClock()
without parameters.

A simple test case to reproduce the issue requires to temporarily move
/etc/localtime file to some other location and then run the following
script:

```
$ perl -MDateTime -E 'DateTime->now(time_zone => "local");'

Use of uninitialized value $clock_file in open at /usr/share/perl5/vendor_perl/DateTime/TimeZone/Local/Unix.pm line 198.
Use of uninitialized value $clock_file in concatenation (.) or string at /usr/share/perl5/vendor_perl/DateTime/TimeZone/Local/Unix.pm line 198.
Cannot read : No such file or directory at /usr/share/perl5/vendor_perl/DateTime/TimeZone/Local/Unix.pm line 198.
```

Signed-off-by: Alexey Molchanov alexey.molchanov@gmail.com
