### PR TITLE
on unix systems, look for /etc/timezone first before /etc/localtime

### DIFF
--- a/lib/DateTime/TimeZone/Local/Unix.pm
+++ b/lib/DateTime/TimeZone/Local/Unix.pm
@@ -9,8 +9,8 @@ use parent 'DateTime::TimeZone::Local';
 sub Methods {
     return qw(
         FromEnv
-        FromEtcLocaltime
         FromEtcTimezone
+        FromEtcLocaltime
         FromEtcTIMEZONE
         FromEtcSysconfigClock
         FromEtcDefaultInit


### PR DESCRIPTION
On ubuntu systems (Etch and later), /etc/localtime is a copy of
/usr/share/zoneinfo/$zonefile, which means DateTime::TimeZone::Local::Unix
spends a lot of time looking for the file that matches it, and it takes a LONG
time (especially when done many times for a single page load!); whereas
/etc/timezone also exists, and this is a simple file that contains the name of
the timezone, so checking for this file first would be much faster.
