### PR TITLE
issue 22: Handle /etc/share/zoneinfo when a symbolic link

### DIFF
--- a/lib/DateTime/TimeZone/Local/Unix.pm
+++ b/lib/DateTime/TimeZone/Local/Unix.pm
@@ -89,7 +89,16 @@ sub _FindMatchingZoneinfoFile {
     shift;
     my $file_to_match = shift;
 
-    return unless -d $ZoneinfoDir;
+    # For some reason, under at least macOS 10.13 High Sierra,
+    # /usr/share/zoneinfo is a link to a link to a directory. And no, I
+    # didn't stutter. This is fine, and it passes the -d below. But
+    # File::Find does not understand a link to be a directory, so rather
+    # than incur the overhead of telling File::Find::find() to follow
+    # symbolic links, we just resolve it here.
+    my $zone_info_dir = $ZoneinfoDir;
+    $zone_info_dir = readlink $zone_info_dir while -l $zone_info_dir;
+
+    return unless -d $zone_info_dir;
 
     require File::Basename;
     require File::Compare;
@@ -127,7 +136,7 @@ sub _FindMatchingZoneinfoFile {
                 },
                 no_chdir => 1,
             },
-            $ZoneinfoDir,
+            $zone_info_dir,
         );
     }
     catch {


### PR DESCRIPTION
This becomes a problem when /etc/localtime is a copy, rather than a
symbolic link, and DateTime::TimeZone::Local::Unix must use File::Find
to traverse all the zone files to figure out which one was copied.

File::Find::find() does not follow symbolic links by default, though
things like -d do. So we resolve the link if necessary before calling
find().

The only instance known to me that triggers this is testing under macOS
13 High Sierra. Actually running under that OS is fine, since
/etc/localtime is a symbolic link. But when testing, a copy is used.