### PR TITLE
Handle "infinity" in parse_olson

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 {{$NEXT}}
 
+- Handle "infinity" as a representation of infinite values in serialized
+  objects. On Solaris we end up with "infinity" and "-infinity" as opposed to
+  just "inf" and "-inf". Fixed by Andrew Paprocki. GH #36.
+
+
 2.34    2019-03-26
 
 - This release is based on version 2019a of the Olson database. This release

--- a/tools/parse_olson
+++ b/tools/parse_olson
@@ -215,8 +215,8 @@ sub parse_file {
 
         my $spans = serialize_spans( zone_as_spans($zone) );
 
-        $spans =~ s/-inf/DateTime::TimeZone::NEG_INFINITY/gi;
-        $spans =~ s/\binf/DateTime::TimeZone::INFINITY/gi;
+        $spans =~ s/-inf(inity)?/DateTime::TimeZone::NEG_INFINITY/gi;
+        $spans =~ s/\binf(inity)?/DateTime::TimeZone::INFINITY/gi;
 
         $spans =~ s/('(?:start|end)_date'\s+=>\s+)'(\d+)'/$1$2/g;
 


### PR DESCRIPTION
It has been noted that on Solaris, the span text will contain "infinity"
when such a value is serialized, but the regex only replaces "inf",
resulting in the build failure:

```
Bareword "DateTime::TimeZone::INFINITYinity" not allowed ...
```