### PR TITLE
Fix Etc/* offset timezones, they were backwards

### DIFF
--- a/lib/DateTime/TimeZone.pm
+++ b/lib/DateTime/TimeZone.pm
@@ -79,7 +79,9 @@ my %SpecialName = map { $_ => 1 }
         }
 
         if ( $p{name} =~ m{Etc/(?:GMT|UTC)(\+|-)(\d{1,2})}i ) {
-            my $sign  = $1;
+            # Etc/GMT+4 is actually UTC-4. For more info, see
+            # https://data.iana.org/time-zones/tzdb/etcetera
+            my $sign  = $1 eq '-' ? '+' : '-';
             my $hours = $2;
             die "The timezone '$p{name}' is an invalid name.\n"
                 unless $hours <= 14;

--- a/t/23etc_zones_offset.t
+++ b/t/23etc_zones_offset.t
@@ -10,15 +10,15 @@ use Test::Fatal;
 my %tz_to_offset = (
     'Etc/GMT-0'   => 0,
     'etc/gmt-0'   => 0,
-    'Etc/GMT+1'   => 3600,
-    'Etc/GMT+12'  => 43200,
-    'Etc/GMT-1'   => -3600,
-    'Etc/GMT-14'  => -50400,
+    'Etc/GMT+1'   => -3600,
+    'Etc/GMT+12'  => -43200,
+    'Etc/GMT-1'   => 3600,
+    'Etc/GMT-14'  => 50400,
     'Etc/GMT-20'  => undef,
     'Etc/GMT-999' => undef,
-    'Etc/UTC+7'   => 25200,
-    'etc/utc+7'   => 25200,
-    'Etc/UTC-9'   => -32400,
+    'Etc/UTC+7'   => -25200,
+    'etc/utc+7'   => -25200,
+    'Etc/UTC-9'   => 32400,
     'Etc/UTC+20'  => undef,
 );
 


### PR DESCRIPTION
Per https://data.iana.org/time-zones/tzdb/etcetera Etc/GMT+4 actually means
UTC-4, so we need to reverse the signs when we ingest these values.

For https://github.com/houseabsolute/DateTime-TimeZone/issues/47