### PR TITLE
Tweaks to allow reusing a previously-compiled database

### DIFF
--- a/tools/tests_from_zdump
+++ b/tools/tests_from_zdump
@@ -151,8 +151,8 @@ sub make_test_file {
                             ([\-\+\w]+)   # local short name
                             \s+
                             isdst=(1|0)
-                            \s+
-                            gmtoff=(-?\d+)
+                            (\s+
+                            gmtoff=(-?\d+))?
                         /x;
 
         unless ($1) {
@@ -167,6 +167,7 @@ sub make_test_file {
         my $utc_month = $months{$utc_mon_name};
         my $loc_month = $months{$loc_mon_name};
 
+        $offset_from_utc //= 0;
         # use '1 * ' to make sure everything is treated as numbers,
         push @tests, {
             time_zone => $tz_name,

--- a/tools/update-from-latest-olson
+++ b/tools/update-from-latest-olson
@@ -13,12 +13,14 @@ sub main {
     my %opts = (
         download => 1,
         tests    => 1,
+        compile  => 1,
     );
 
     GetOptions(
         'download!' => \$opts{download},
         'dir:s'     => \$opts{dir},
         'tests!'    => \$opts{tests},
+        'compile!'  => \$opts{compile},
     );
 
     my $olson_version;
@@ -34,7 +36,9 @@ sub main {
         ($olson_version) = $dir =~ m{/([^/]+)$};
     }
 
-    _compile_tzdata($dir);
+    if ( $opts{compile} ) {
+        _compile_tzdata($dir);
+    }
     _parse_olson( $dir, $olson_version, $opts{tests} );
 }
 


### PR DESCRIPTION
Ulterior motive: This allows generating DateTime::TimeZone using the global-tz fork of olsondb (https://github.com/JodaOrg/global-tz/tree/main).

This just adds two minor tweaks to the scripts in the tools directory -- one to allow skipping the compilation step (if `--no-compile` is given as an option), and one to allow for a slight difference in the global-tz generated files, which has lines like the following, which don't include the gmtoff parameter.

```
America/Argentina/Cordoba  Fri Dec 13 20:45:52 1901 UTC = Fri Dec 13 16:29:04 1901 CMT isdst=0
```