### PR TITLE
Tweaks to allow reusing a previously-compiled database

### DIFF
--- a/tools/update-from-latest-olson
+++ b/tools/update-from-latest-olson
@@ -13,12 +13,14 @@ sub main {
     my %opts = (
         download => 1,
         tests    => 1,
+        compile  => 1,
     );
 
     GetOptions(
         'download!' => \$opts{download},
         'dir:s'     => \$opts{dir},
         'tests!'    => \$opts{tests},
+        'compile!'  => \$opts{compile},
     );
 
     my $olson_version;
@@ -34,7 +36,9 @@ sub main {
         ($olson_version) = $dir =~ m{/([^/]+)$};
     }
 
-    _compile_tzdata($dir);
+    if ( $opts{compile} ) {
+        _compile_tzdata($dir);
+    }
     _parse_olson( $dir, $olson_version, $opts{tests} );
 }
 


### PR DESCRIPTION
Ulterior motive: This allows generating DateTime::TimeZone using the global-tz fork of olsondb (https://github.com/JodaOrg/global-tz/tree/main).

This just adds a minor tweak to `tools/update-from-latest-olson` to allow skipping the compilation step if --no-compile is given as an option.